### PR TITLE
Use more consistent README title

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# jddf [![][crates-badge]][crates-url] [![][ci-badge]][ci-url]
+# jddf-rust [![][crates-badge]][crates-url] [![][ci-badge]][ci-url]
 
 > Documentation on docs.rs: https://docs.rs/jddf
 


### PR DESCRIPTION
This PR updates the README title to using the naming convention followed by most implementations of JDDF.