### PR TITLE
Include definitions in into_serde

### DIFF
--- a/src/schema.rs
+++ b/src/schema.rs
@@ -238,6 +238,15 @@ impl Schema {
     pub fn into_serde(self) -> Serde {
         let mut out = Serde::default();
 
+        if let Some(defs) = self.defs {
+            let mut out_defs = HashMap::new();
+            for (name, value) in defs {
+                out_defs.insert(name, value.into_serde());
+            }
+
+            out.defs = Some(out_defs);
+        }
+
         match *self.form {
             Form::Empty => {}
             Form::Ref(def) => {


### PR DESCRIPTION
`into_serde` does not include definitions in its output. This PR fixes that.